### PR TITLE
Add Netlify links

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,4 +8,4 @@ Available at: [scanapi.dev](https://scanapi.dev)
 
 ## Tech Stack
 - Jekyll
-- Deploy on GitHub Pages
+- Deploys by [Netlify](https://www.netlify.com)

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -16,7 +16,7 @@
         </div>
         <div class="footer-copyright-text">
             <span>The contents of this website are © 2020 under the terms of the <a href="https://github.com/scanapi/website/blob/master/LICENSE">MIT License</a>. </span>
-            <span>Hosted by GitHub Pages</span>
+            <span>This site is powered by <a href="https://www.netlify.com">Netlify</a>.</span>
         </div>
     </div>
 


### PR DESCRIPTION
I applied to Netlify's Open Source Plan. This is the answer I received:

> Hello!

> Thank you for applying for our Open source plan. Your application looks good however we require a link to our service on your project's main web page for your website's visitors to see (so, not just in your repository documentation or on a sponsors page). You have two options: we have premade badges for your convenience, or you may create your own link, which should read “This site is powered by Netlify”. Either should link back to our home page, https://www.netlify.com.
> 
> Let us know when that is done and we'll set up your open source team.
> 
> Thank you!

This PR implements the missing links.

Related to: https://github.com/scanapi/website/issues/14