### PR TITLE
Change config file default name to scanapi.conf

### DIFF
--- a/_docs_v1/configuration/config_file.md
+++ b/_docs_v1/configuration/config_file.md
@@ -11,7 +11,7 @@ index: 1
 
 # Configuration File
 
-If you want to configure the ScanAPI with a file, you can create a `.scanapi.yaml` file in the root of your project
+If you want to configure the ScanAPI with a file, you can create a local `scanapi.conf` file where you are running the ScanAPI CLI or a global `scanapi.conf` file following the XDG Base Directory Specification.
 
 ```yaml
 project_name: DemoAPI # This will be rendered in the Report Title.

--- a/_docs_v1/configuration/hiding_sensitive_information.md
+++ b/_docs_v1/configuration/hiding_sensitive_information.md
@@ -11,8 +11,7 @@ index: 2
 
 # Hiding Sensitive Information
 
-If you want to omit sensitive information in the report, you can configure it in the `.scanapi.yaml`
-file.
+If you want to omit sensitive information in the report, you can configure it in the `scanapi.conf` file.
 
 ```yaml
 report:


### PR DESCRIPTION
## Update Documentation with new default config file name

Before, the default config file name was `.scanapi.yaml`. Now it is `scanapi.conf`. Documentation should reflect this change.

Depending on https://github.com/scanapi/scanapi/pull/254
Closes: https://github.com/scanapi/website/issues/22