### PR TITLE
Add delay key to the documentation

### DIFF
--- a/_docs_v1/specification/api_specification_keys.md
+++ b/_docs_v1/specification/api_specification_keys.md
@@ -15,6 +15,7 @@ index: 1
 | ---------------- | ----------------------------------------------------------------------------------------------------- | ------ | --------------------------------- |
 | assert           | The test assertion                                                                                    | dict   | tests                             |
 | body             | The HTTP body of the request                                                                          | dict   | request                           |
+| delay            | Performs a delay in milliseconds before each request call. (Available for version >= 2.1.0)           | int    | endpoint, request                 |
 | endpoints        | Represents a list of API endpoints                                                                    | list   | endpoint                          |
 | headers          | The HTTP headers                                                                                      | dict   | endpoint, request                 |
 | method           | The HTTP method of the request (GET, POST, PUT, PATCH or DELETE). If not set, GET will be used        | string | request                           |

--- a/_docs_v1/specification/basic_structure.md
+++ b/_docs_v1/specification/basic_structure.md
@@ -55,6 +55,7 @@ request = leaf
 
 Each item of the endpoints list has the following keys available:
 
+- \- delay
 - \- endpoints
 - \- headers
 - \- name
@@ -74,6 +75,7 @@ Requests can only be defined under an endpoint.
 Each item of the requests list has the following keys available:
 
 - \- body
+- \- delay
 - \- headers
 - \- method
 - \- name
@@ -109,6 +111,12 @@ syntax: python code
 The content that will be sent as the HTTP request body.
 
 type: dict
+
+## delay
+
+The time in milliseconds to perform a delay before each request call. (Available for version >= 2.1.0)
+
+type: int
 
 ## endpoints
 


### PR DESCRIPTION
- Add `delay` key to the documentation.
- Closes https://github.com/scanapi/website/issues/41.