### PR TITLE
🎨 Adjust home css for mobile

### DIFF
--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -5,11 +5,11 @@
             {% for item in site.data.navigation %}
                 <a href="{{ item.link | relative_url}}" {% if page.url == item.link %} class="current"{% endif %}>{{ item.name }}</a>
             {% endfor %}
-            <a href="https://github.com/scanapi/examples">Examples</a>
+            <a href="https://github.com/scanapi/examples", target="_blank">Examples</a>
 
-            <a href="https://github.com/marketplace/actions/scanapi">GitHub Action</a>
+            <a href="https://github.com/marketplace/actions/scanapi", target="_blank">GitHub Action</a>
 
-            <a href="https://marketplace.visualstudio.com/items?itemName=ScanAPI.scanapi">VS Code Plugin</a>
+            <a href="https://marketplace.visualstudio.com/items?itemName=ScanAPI.scanapi", target="_blank">VS Code Plugin</a>
 
             <a class="nav-icon" href="https://twitter.com/scanapi_"> <img src="{{ "/assets/images/twitter.svg" | relative_url }}"></a>
             <a class="nav-icon" href="https://github.com/scanapi/scanapi"><img src="{{ "/assets/images/github-logo.svg" | relative_url }}"></a>

--- a/_sass/index.scss
+++ b/_sass/index.scss
@@ -13,6 +13,7 @@ section {
     background-repeat: no-repeat;
     background-size: cover;
     margin-bottom: 80px;
+    box-shadow: 0px 3px 10px 0px $shadow-color;
     h1 {
         font-size: 56px;
         width: 600px;
@@ -41,6 +42,7 @@ section {
         color: $light-color;
         font-size: $normal-font-size;
         text-transform: uppercase;
+        filter: drop-shadow(4px 3px 5px $shadow-color);
     }
 }
 
@@ -74,13 +76,18 @@ section {
 
 .section-reports {
     width: 80%;
-    height: 400px;
+    height: 100%;
     display: flex;
     align-items: center;
     justify-content: flex-end;
+    padding: 5% 10%;
+    margin: 0;
+    background-color: $light-primary-color;
+    box-shadow: 0px 2px 5px 0px $shadow-color;
     img {
         height: 350px;
         margin-left: 10px;
+        filter: drop-shadow(5px 5px 5px $shadow-color);
     }
     div {
         display: flex;
@@ -101,18 +108,23 @@ section {
 .section-integration-tests {
     width:80%;
     margin: auto;
-    height: 400px;
+    height: 100%;
     display: flex;
     align-items: center;
     justify-content: flex-start;
-    margin-bottom: 50px;
+    padding: 5% 10%;
+    margin: 0;
     img {
         height: 350px;
         margin-right: 10px;
+        filter: drop-shadow(5px 5px 5px $shadow-color);
+        padding: 0 5%;
     }
     div {
         display: flex;
         flex-direction: column;
+        max-height: 100%;
+        position: relative;
     }
     h2 {
         font-weight: 700;
@@ -123,6 +135,7 @@ section {
     h3 {
         color: $primary-color;
         font-weight: bold;
+        padding: 10px 0px;
     }
     p {
         font-size: $normal-font-size;

--- a/_sass/main.scss
+++ b/_sass/main.scss
@@ -2,6 +2,8 @@ $base-gray: #232020;
 $light-color: #FFFFFF;
 $darker-color: #161616;
 $primary-color: #FF7163;
+$light-primary-color: #FCE8E6;
+$shadow-color: #AFAFAF;
 $normal-font-size: 18px;
 $large-font-size: 26px;
 $larger-font-size: 40px;


### PR DESCRIPTION
## Description

Adjust Home CSS
- To avoid breaking on mobile
- Add to report section a background color
- Add shadows

Add taget blank to external links in the navigation bar
## Before

![IMG_0A59CF70CE88-1](https://user-images.githubusercontent.com/2728804/104509514-8ea61000-55c8-11eb-9802-faddf30e1018.jpeg)

---

![image](https://user-images.githubusercontent.com/2728804/104509537-92d22d80-55c8-11eb-8e9e-71f87bfa293e.png)

## After

![image](https://user-images.githubusercontent.com/2728804/104509756-dfb60400-55c8-11eb-96c3-2875867801c9.png)

---

![image](https://user-images.githubusercontent.com/2728804/104509857-07a56780-55c9-11eb-864a-cc8773268966.png)


closes https://github.com/scanapi/website/issues/51