### PR TITLE
Add a json example to API Spec in Multiple Files documentation

### DIFF
--- a/_docs_v1/specification/api_spec_in_multiple_files.md
+++ b/_docs_v1/specification/api_spec_in_multiple_files.md
@@ -39,3 +39,47 @@ endpoints:
       - name: health
         path: /health/
 ```
+
+The same works for JSON specifications:
+
+```jsonc
+// scanapi.json
+{
+  "endpoints": [
+    {
+      "name": "scanapi-demo",
+      "path": "${BASE_URL}",
+      "requests": !include include.json
+    }
+  ]
+}
+```
+
+```jsonc
+// include.json
+[
+  {
+    "name": "health",
+    "path": "/health/"
+  }
+]
+```
+
+would generate:
+
+```json
+{
+  "endpoints": [
+    {
+      "name": "scanapi-demo",
+      "path": "${BASE_URL}",
+      "requests": [
+        {
+          "name": "health",
+          "path": "/health/"
+        }
+      ]
+    }
+  ]
+}
+```


### PR DESCRIPTION
## Description

Add a json example to API Specification in Multiple Files documentation

Closes #37
