### PR TITLE
fix: Tutorial Endpoints to Use HTTPS Instead of HTTP

### DIFF
--- a/_tutorials/step02.md
+++ b/_tutorials/step02.md
@@ -20,9 +20,9 @@ This is an example of a code snippet:
 
 ```json
 {
-  "url": "http://demo.scanapi.dev/api/v1/snippets/2/",
+  "url": "https://demo.scanapi.dev/api/v1/snippets/2/",
   "id": 2,
-  "highlight": "http://demo.scanapi.dev/api/v1/snippets/2/highlight/",
+  "highlight": "https://demo.scanapi.dev/api/v1/snippets/2/highlight/",
   "owner": "admin",
   "title": "Calculator",
   "code": "def add(x, y):\r\n    return x + y\r\n\r\ndef subtract(x, y):\r\n    return x - y\r\n\r\ndef multiply(x, y):\r\n    return x * y\r\n\r\ndef divide(x, y):\r\n    return x / y",

--- a/_tutorials/step03.md
+++ b/_tutorials/step03.md
@@ -19,7 +19,7 @@ Let’s add your ScanAPI spec. Create `scanapi.yaml` in root with the following 
 ```yaml
 endpoints:
   - name: snippets-api
-    path: http://demo.scanapi.dev/api/v1/
+    path: https://demo.scanapi.dev/api/v1/
     headers:
       Content-Type: application/json
     requests:
@@ -46,7 +46,7 @@ From the output of the command, you can see that ScanAPI:
 ```shell
 INFO     Loading file scanapi.yaml # loads the specification file you created
 
-- Making request GET http://demo.scanapi.dev/api/v1/health/  # makes a GET request to the /health path
+- Making request GET https://demo.scanapi.dev/api/v1/health/  # makes a GET request to the /health path
 The documentation was generated successfully.
 It is available at -> <your_root_path>/scanapi-report.html # generates the API documentation
 ```
@@ -81,7 +81,7 @@ curl -X GET \
 -H "Accept: */*" \
 -H "Connection: keep-alive" \
 -H "Content-Type: application/json" \
--d 'None' http://demo.scanapi.dev/api/v1/health/ --compressed
+-d 'None' https://demo.scanapi.dev/api/v1/health/ --compressed
 ```
 
 And then, the response details:

--- a/_tutorials/step04.md
+++ b/_tutorials/step04.md
@@ -11,7 +11,7 @@ the following content:
 ```yaml
 {% raw %}endpoints:
   - name: snippets-api
-    path: http://demo.scanapi.dev/api/v1/
+    path: https://demo.scanapi.dev/api/v1/
     headers:
       Content-Type: application/json
     requests:

--- a/_tutorials/step05.md
+++ b/_tutorials/step05.md
@@ -74,7 +74,7 @@ In the `scanapi.yaml` file, add the `get_token` request:
 ```yaml
 {% raw %}endpoints:
   - name: snippets-api
-    path: http://demo.scanapi.dev/api/v1/
+    path: https://demo.scanapi.dev/api/v1/
     headers:
       Content-Type: application/json
     requests:

--- a/_tutorials/step07.md
+++ b/_tutorials/step07.md
@@ -26,7 +26,7 @@ Putting it all together:
 ```yaml
 {% raw %}endpoints:
   - name: snippets-api
-    path: http://demo.scanapi.dev/api/v1/
+    path: https://demo.scanapi.dev/api/v1/
     headers:
       Content-Type: application/json
     requests:
@@ -105,7 +105,7 @@ Putting it all together:
 ```yaml
 {% raw %}endpoints:
   - name: snippets-api
-    path: http://demo.scanapi.dev/api/v1/
+    path: https://demo.scanapi.dev/api/v1/
     headers:
       Content-Type: application/json
     requests:
@@ -218,7 +218,7 @@ Putting it all together:
 ```yaml
 {% raw %}endpoints:
   - name: snippets-api
-    path: http://demo.scanapi.dev/api/v1/
+    path: https://demo.scanapi.dev/api/v1/
     headers:
       Content-Type: application/json
     requests:
@@ -276,7 +276,7 @@ Let's go ahead and add more snippet requests:
 ```yaml
 {% raw %}endpoints:
   - name: snippets-api
-    path: http://demo.scanapi.dev/api/v1/
+    path: https://demo.scanapi.dev/api/v1/
     headers:
       Content-Type: application/json
     requests:

--- a/_tutorials/step08.md
+++ b/_tutorials/step08.md
@@ -15,7 +15,7 @@ Let's see how we could rewrite our specification file `scanapi.yaml` using neste
 ```yaml
 {% raw %}endpoints:
   - name: snippets-api
-    path: http://demo.scanapi.dev/api/v1/
+    path: https://demo.scanapi.dev/api/v1/
     headers:
       Content-Type: application/json
     requests:

--- a/_tutorials/step09.md
+++ b/_tutorials/step09.md
@@ -11,7 +11,7 @@ spec.
 ```yaml
 {% raw %}endpoints:
   - name: snippets-api
-    path: http://demo.scanapi.dev/api/v1/
+    path: https://demo.scanapi.dev/api/v1/
     headers:
       Content-Type: application/json
     requests:
@@ -92,7 +92,7 @@ endpoint path, you can skip it. Let's remove all `path: /` from our spec.
 ```yaml
 {% raw %}endpoints:
   - name: snippets-api
-    path: http://demo.scanapi.dev/api/v1/
+    path: https://demo.scanapi.dev/api/v1/
     headers:
       Content-Type: application/json
     requests:

--- a/_tutorials/step10.md
+++ b/_tutorials/step10.md
@@ -74,7 +74,7 @@ The file `scanapi.yaml` should look like this now:
 ```yaml
 {% raw %} endpoints:
   - name: snippets-api
-    path: http://demo.scanapi.dev/api/v1/
+    path: https://demo.scanapi.dev/api/v1/
     headers:
       Content-Type: application/json
     requests:

--- a/_tutorials/step13.md
+++ b/_tutorials/step13.md
@@ -95,7 +95,7 @@ jobs:
 If you would try to run this action, you would receive the following error:
 
 ```shell
-Error to make request `http://demo.scanapi.dev/api/v1/rest-auth/login/`.
+Error to make request `https://demo.scanapi.dev/api/v1/rest-auth/login/`.
 'USER' environment variable not set or badly configured
 ```
 
@@ -251,7 +251,7 @@ Save, commit and push your changes to your `main` branch.
 If you would try to run this workflow, you would receive the following error:
 
 ```shell
-Error to make request `http://demo.scanapi.dev/api/v1/rest-auth/login/`.
+Error to make request `https://demo.scanapi.dev/api/v1/rest-auth/login/`.
 'USER' environment variable not set or badly configured
 ```
 


### PR DESCRIPTION
## Description

This PR updates the tutorial to replace all `http` endpoints with `https`, ensuring the documentation reflects the correct and secure API URL.

### Changes

- Replaced `http://demo.scanapi.dev/api/v1/` with `https://demo.scanapi.dev/api/v1/` across the tutorial.
- Improved consistency in documentation examples.
- Prevented potential confusion when accessing the API.

### Motivation

Using `https` is essential for secure communication and aligns the tutorial with the actual API configuration.

### Testing

- Reviewed all tutorial sections to ensure no `http` references remain.
- Validated that the updated endpoint works as expected.

### Related Issue

Closes: #107 